### PR TITLE
Bumped version number for the alfresco-utilily dependency

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -69,7 +69,7 @@
         <!-- TODO Refactor Maven coordinates once available / stable name has been found -->
         <common.artifactId>de.acosix.alfresco.ignite.common</common.artifactId>
 
-        <acosix.utility.version>1.0.3.0-SNAPSHOT</acosix.utility.version>
+        <acosix.utility.version>1.0.4.0-SNAPSHOT</acosix.utility.version>
         <apache.ignite.version>2.7.0</apache.ignite.version>
 
         <fabric8io.docker.version>0.28-SNAPSHOT</fabric8io.docker.version>


### PR DESCRIPTION
Building the module failed due to a dependency problem - seems to be due to the renaming of packages to include `core`, which was not found in the alfresco-utility snapshot version in my local `.m2` folder (after it had been installed).

The build is working again if we bump the dependency version of the alfresco-utility module to 1.0.4.0