### PR TITLE
Release deploy preparation

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,0 +1,31 @@
+## BUG
+
+### Expected behavior
+
+
+### Actual behavior
+
+
+### Steps to reproduce the behavior
+
+
+### Additional details (analysis so far, log statements, references, etc.)
+
+
+### Tell us about your environment
+
+
+
+## FEATURE / ENHANCEMENT
+
+If you are requesting a feature or enhancement, please provide as much information as
+possible and let us know how you will be able to contribute to resolving the request.
+
+If you write code and can code up the solution, we welcome PRs. If you can do this but
+would like guidance from the core team let us know.
+
+Are you willing/able to test any work we do towards your request?
+
+If you plan to contribute to the project and you are not familiar with our current
+contribution policy, please make sure you have read that document (HINT: there is
+a link at the top of the page when you are creating an issue.)

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,30 @@
+### CHECKLIST
+
+We will not consider a PR until the following items are checked off--thank you!
+
+- [ ] There aren't existing pull requests attempting to address the issue mentioned here
+- [ ] Submission developed in a feature branch--not master
+
+### CONVINCING DESCRIPTION
+
+... Describe the changes provided by this PR...
+
+### RELATED INFORMATION
+
+... If you have any supporting material such as issues that are addressed by this
+PR, links outlining any special techniques or libraries used, etc that will help
+us to evaluate this PR. Please include that information here...
+
+Fixes #
+
+# BE WARNED
+
+- If any of the checklist items are missed, incomplete or invalid we will not accept the PR
+- If you are not responsive to feedback on your PR we will not accept the PR
+- If we do not accept your PR we will provide feedback on the PR indicating why
+- After some time, we will close PRs that have not been accepted
+
+When we decline or close your PR. You are encouraged to address the concerns outlined in the
+PR and then re-submit it. We want contributions. We also need for them to be of high quality
+and high value and to not take undue resources away from the features and enhancements the
+core team is working on. Thanks for understanding!

--- a/NOTICE
+++ b/NOTICE
@@ -1,19 +1,19 @@
 Alfresco Community Open Grid
-Copyright 2019 Acosix GmbH
-Copyright 2019 MAGENTA ApS
+Copyright 2020 Acosix GmbH
+Copyright 2020 MAGENTA ApS
 
 
 This software includes code from Apache Ignite
-Copyright 2019 The Apache Software Foundation
+Copyright 2020 The Apache Software Foundation
 https://ignite.apache.org/
 Licensed under Apache License, Version 2.0
-https://search.maven.org/artifact/org.apache.ignite/ignite-core/2.7.5/jar
-https://search.maven.org/artifact/org.apache.ignite/ignite-web/2.7.5/jar
-https://search.maven.org/artifact/org.apache.ignite/ignite-slf4j/2.7.5/jar
+https://search.maven.org/artifact/org.apache.ignite/ignite-core/2.8.1/jar
+https://search.maven.org/artifact/org.apache.ignite/ignite-web/2.8.1/jar
+https://search.maven.org/artifact/org.apache.ignite/ignite-slf4j/2.8.1/jar
 
 
 This software includes code from IntelliJ IDEA Community Edition
 Copyright (C) JetBrains s.r.o.
 https://www.jetbrains.com/idea/
 Licensed under Apache License, Version 2.0
-https://search.maven.org/artifact/org.jetbrains/annotations/13.0/jar
+https://search.maven.org/artifact/org.jetbrains/annotations/16.0.3/jar

--- a/common/pom.xml
+++ b/common/pom.xml
@@ -9,7 +9,7 @@
     <parent>
         <groupId>org.aldica</groupId>
         <artifactId>aldica-parent</artifactId>
-        <version>1.0.0-SNAPSHOT</version>
+        <version>1.0.0</version>
     </parent>
 
     <artifactId>aldica-common-ignite</artifactId>

--- a/common/src/main/java/org/aldica/common/ignite/plugin/SimpleSecurityPluginProvider.java
+++ b/common/src/main/java/org/aldica/common/ignite/plugin/SimpleSecurityPluginProvider.java
@@ -64,7 +64,7 @@ public class SimpleSecurityPluginProvider implements PluginProvider<SimpleSecuri
     @Override
     public String copyright()
     {
-        return "Copyright 2019 Acosix GmbH, Copyright 2019 MAGENTA ApS";
+        return "Copyright 2020 Acosix GmbH, Copyright 2020 MAGENTA ApS";
     }
 
     /**

--- a/docker/Dockerfile.repo.build
+++ b/docker/Dockerfile.repo.build
@@ -8,6 +8,7 @@ ADD NOTICE .
 ADD pom.xml .
 ADD common common
 ADD repository repository
+ADD repository-companion repository-companion
 ADD share share
 # The Share folder needs to be there - otherwise Maven complains
 
@@ -17,15 +18,15 @@ RUN sed -i 's/de.acosix.alfresco.maven.project.parent-6.1.2/de.acosix.alfresco.m
 
 # Build aldica and copy dependencies
 RUN mvn install -B -T2C -DskipTests -Dquality.findBugs.skip -pl common,repository
-RUN mvn dependency:copy -Dartifact=de.acosix.alfresco.utility:de.acosix.alfresco.utility.core.repo:1.2.1:amp -DoutputDirectory=target -B
+RUN mvn dependency:copy -Dartifact=de.acosix.alfresco.utility:de.acosix.alfresco.utility.core.repo:1.2.2:amp -DoutputDirectory=target -B
 
 # Build aldica-enabled Alfresco Repository
 FROM alfresco/alfresco-content-repository-community:6.2.0-ga
 
-COPY --from=0 --chown=root:Alfresco /aldica/repository/target/aldica-repo-ignite-1.0.0-SNAPSHOT.amp .
-COPY --from=0 --chown=root:Alfresco /aldica/target/de.acosix.alfresco.utility.core.repo-1.2.1.amp .
+COPY --from=0 --chown=root:Alfresco /aldica/repository/target/aldica-repo-ignite-*.amp .
+COPY --from=0 --chown=root:Alfresco /aldica/target/de.acosix.alfresco.utility.core.repo-*.amp .
 
 USER root
-RUN java -jar alfresco-mmt/alfresco-mmt-6.0.jar install de.acosix.alfresco.utility.core.repo-1.2.1.amp webapps/alfresco -nobackup
-RUN java -jar alfresco-mmt/alfresco-mmt-6.0.jar install aldica-repo-ignite-1.0.0-SNAPSHOT.amp webapps/alfresco -nobackup
+RUN java -jar alfresco-mmt/alfresco-mmt-6.0.jar install de.acosix.alfresco.utility.core.repo-*.amp webapps/alfresco -nobackup
+RUN java -jar alfresco-mmt/alfresco-mmt-6.0.jar install aldica-repo-ignite-*.amp webapps/alfresco -nobackup
 USER alfresco

--- a/docker/Dockerfile.repo.download
+++ b/docker/Dockerfile.repo.download
@@ -1,0 +1,18 @@
+# Download AMPs
+FROM maven:3-jdk-11
+
+RUN mvn dependency:copy -Dartifact=de.acosix.alfresco.utility:de.acosix.alfresco.utility.core.repo:1.2.2:amp -DoutputDirectory=/tmp -B
+RUN mvn dependency:copy -Dartifact=org.aldica:aldica-repo-ignite:1.0.0:amp -DoutputDirectory=/tmp -B
+
+# Build aldica-enabled Alfresco Repository
+FROM alfresco/alfresco-content-repository-community:6.2.0-ga
+
+COPY --from=0 --chown=root:Alfresco /tmp/aldica-repo-ignite-1.0.0.amp .
+COPY --from=0 --chown=root:Alfresco /tmp/de.acosix.alfresco.utility.core.repo-1.2.2.amp .
+
+USER root
+
+RUN java -jar alfresco-mmt/alfresco-mmt-6.0.jar install de.acosix.alfresco.utility.core.repo-1.2.2.amp webapps/alfresco -nobackup
+RUN java -jar alfresco-mmt/alfresco-mmt-6.0.jar install aldica-repo-ignite-1.0.0.amp webapps/alfresco -nobackup
+
+USER alfresco

--- a/docker/Dockerfile.share.build
+++ b/docker/Dockerfile.share.build
@@ -8,6 +8,7 @@ ADD NOTICE .
 ADD pom.xml .
 ADD common common
 ADD repository repository
+ADD repository-companion repository-companion
 ADD share share
 
 # Substitute Acosix Alfresco parent version in the POM
@@ -16,13 +17,13 @@ RUN sed -i 's/de.acosix.alfresco.maven.project.parent-6.1.2/de.acosix.alfresco.m
 
 # Build aldica and copy dependencies (we need to build both repo and share due to dependency issues)
 RUN mvn install -B -T2C -DskipTests -Dquality.findBugs.skip
-RUN mvn dependency:copy -Dartifact=de.acosix.alfresco.utility:de.acosix.alfresco.utility.core.share:1.2.1:amp -DoutputDirectory=target -B
+RUN mvn dependency:copy -Dartifact=de.acosix.alfresco.utility:de.acosix.alfresco.utility.core.share:1.2.2:amp -DoutputDirectory=target -B
 
 # Build aldica-enabled Alfresco Share
 FROM alfresco/alfresco-share:6.2.0
 
-COPY --from=0 /aldica/share/target/aldica-share-ignite-1.0.0-SNAPSHOT.amp .
-COPY --from=0 /aldica/target/de.acosix.alfresco.utility.core.share-1.2.1.amp .
+COPY --from=0 /aldica/share/target/aldica-share-ignite-*.amp .
+COPY --from=0 /aldica/target/de.acosix.alfresco.utility.core.share-*.amp .
 
-RUN java -jar alfresco-mmt/alfresco-mmt-6.0.jar install de.acosix.alfresco.utility.core.share-1.2.1.amp webapps/share -force -nobackup
-RUN java -jar alfresco-mmt/alfresco-mmt-6.0.jar install aldica-share-ignite-1.0.0-SNAPSHOT.amp webapps/share -nobackup
+RUN java -jar alfresco-mmt/alfresco-mmt-6.0.jar install de.acosix.alfresco.utility.core.share-*.amp webapps/share -force -nobackup
+RUN java -jar alfresco-mmt/alfresco-mmt-6.0.jar install aldica-share-ignite-*.amp webapps/share -nobackup

--- a/docker/Dockerfile.share.download
+++ b/docker/Dockerfile.share.download
@@ -1,0 +1,14 @@
+# Download AMPs
+FROM maven:3-jdk-11
+
+RUN mvn dependency:copy -Dartifact=de.acosix.alfresco.utility:de.acosix.alfresco.utility.core.share:1.2.2:amp -DoutputDirectory=/tmp -B
+RUN mvn dependency:copy -Dartifact=org.aldica:aldica-share-ignite:1.0.0:amp -DoutputDirectory=/tmp -B
+
+# Build aldica-enabled Alfresco Share
+FROM alfresco/alfresco-share:6.2.0
+
+COPY --from=0 /tmp/aldica-share-ignite-1.0.0-SNAPSHOT.amp .
+COPY --from=0 /tmp/de.acosix.alfresco.utility.core.share-1.2.2.amp .
+
+RUN java -jar alfresco-mmt/alfresco-mmt-6.0.jar install de.acosix.alfresco.utility.core.share-1.2.2.amp webapps/share -force -nobackup
+RUN java -jar alfresco-mmt/alfresco-mmt-6.0.jar install aldica-share-ignite-1.0.0.amp webapps/share -nobackup

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -12,7 +12,7 @@ services:
     alfresco:
         build:
           context: ..
-          dockerfile: docker/Dockerfile.repo
+          dockerfile: docker/Dockerfile.repo.build
         mem_limit: 1500m
         environment:
             JAVA_OPTS: "
@@ -94,7 +94,7 @@ services:
     share:
         build:
           context: ..
-          dockerfile: docker/Dockerfile.share
+          dockerfile: docker/Dockerfile.share.build
         mem_limit: 1g
         environment:
             REPO_HOST: "alfresco"

--- a/docs/Test-Memory-BM.md
+++ b/docs/Test-Memory-BM.md
@@ -98,9 +98,9 @@ In order to test the various levels of [binary serialisation optimisations](./Co
 
 ### Collected Metrics
 
-Date of benchmark: 2020-06-30 / 2020-07-01
-System: Lenovo T460p, Intel Core i7-6700HQ @ 2.60 GHz, 4 Core, 32 GiB RAM, Windows 10, Docker for Desktop (2 CPU, 14 GiB RAM assigned), SAMSUNG MZ7LN512HMJP 512 GiB SSD
-Concurrent threads: 6
+- Date of benchmark: 2020-06-30 / 2020-07-01
+- System: Lenovo T460p, Intel Core i7-6700HQ @ 2.60 GHz, 4 Core, 32 GiB RAM, Windows 10, Docker for Desktop (2 CPU, 14 GiB RAM assigned), SAMSUNG MZ7LN512HMJP 512 GiB SSD
+- Concurrent threads: 6
 
 | Measure | Alfresco 6.1.2 | aldica (medium opt) | aldica (default / max opt) | aldica (min opt) |
 | :--- | ---: | ---: | ---: | ---: |

--- a/memory-bm/pom.xml
+++ b/memory-bm/pom.xml
@@ -9,7 +9,7 @@
     <parent>
         <groupId>org.aldica</groupId>
         <artifactId>aldica-parent</artifactId>
-        <version>1.0.0-SNAPSHOT</version>
+        <version>1.0.0</version>
     </parent>
 
     <artifactId>aldica-repo-ignite-mem-bm</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -148,12 +148,12 @@
 
     <distributionManagement>
         <repository>
-            <id>acosix-nexus</id>
-            <url>http://acosix.de/nexus/content/repositories/releases/</url>
+            <id>ossrh</id>
+            <url>https://oss.sonatype.org/service/local/staging/deploy/maven2/</url>
         </repository>
         <snapshotRepository>
-            <id>acosix-nexus</id>
-            <url>http://acosix.de/nexus/content/repositories/snapshots/</url>
+            <id>ossrh</id>
+            <url>https://oss.sonatype.org/content/repositories/snapshots</url>
         </snapshotRepository>
     </distributionManagement>
 

--- a/pom.xml
+++ b/pom.xml
@@ -14,7 +14,7 @@
 
     <groupId>org.aldica</groupId>
     <artifactId>aldica-parent</artifactId>
-    <version>1.0.0-SNAPSHOT</version>
+    <version>1.0.0</version>
     <packaging>pom</packaging>
 
     <name>Alternative/Alfresco Distributed Cache - Parent</name>

--- a/pom.xml
+++ b/pom.xml
@@ -8,9 +8,8 @@
 
     <parent>
         <groupId>de.acosix.alfresco.maven</groupId>
-        <!-- <artifactId>de.acosix.alfresco.maven.project.parent-6.2.0</artifactId> -->
         <artifactId>de.acosix.alfresco.maven.project.parent-6.1.2</artifactId>
-        <version>1.3.1</version>
+        <version>1.3.2</version>
     </parent>
 
     <groupId>org.aldica</groupId>
@@ -21,8 +20,7 @@
     <name>Alternative/Alfresco Distributed Cache - Parent</name>
     <description>Addon providing distributed caching and data grid capabilities to Alfresco Content Services and Share</description>
 
-    <!-- temporary details pending completion of open sourcing process -->
-    <url>https://github.com/AFaust/alfresco-community-open-grid</url>
+    <url>https://github.com/aldica/aldica</url>
 
     <licenses>
         <license>
@@ -32,9 +30,9 @@
     </licenses>
 
     <scm>
-        <connection>scm:git:git@github.com:AFaust/alfresco-community-open-grid.git</connection>
-        <developerConnection>scm:git:git@github.com:AFaust/alfresco-community-open-grid.git</developerConnection>
-        <url>git@github.com:AFaust/alfresco-community-open-grid.git</url>
+        <connection>scm:git:git@github.com:aldica/aldica.git</connection>
+        <developerConnection>scm:git:git@github.com:aldica/aldica.git</developerConnection>
+        <url>git@github.com:aldica/aldica.git</url>
     </scm>
 
     <developers>
@@ -71,7 +69,7 @@
         <aldica.ignite-common.basePackage>org.aldica.common.ignite</aldica.ignite-common.basePackage>
         <aldica.ignite-repo.artifactId>aldica-repo-ignite</aldica.ignite-repo.artifactId>
 
-        <acosix.utility.version>1.2.2-SNAPSHOT</acosix.utility.version>
+        <acosix.utility.version>1.2.2</acosix.utility.version>
         <ootbee.support-tools.version>1.1.0.0</ootbee.support-tools.version>
         <apache.ignite.version>2.8.1</apache.ignite.version>
         <easymock.version>4.2</easymock.version>

--- a/pom.xml
+++ b/pom.xml
@@ -50,8 +50,24 @@
                 <twitter>twitter.com/ReluctantBird83</twitter>
             </properties>
         </developer>
-        
-        <!-- TODO Add details of Magenta Apps collaborators -->
+        <developer>
+            <id>andreaskring</id>
+            <name>Andreas Kring</name>
+            <email>andreas@magenta.dk</email>
+            <organization>Magenta ApS</organization>
+            <roles>
+                <role>Developer</role>
+            </roles>
+        </developer>
+        <developer>
+            <id>skeen</id>
+            <name>Emil Madsen</name>
+            <email>emil@magenta.dk</email>
+            <organization>Magenta ApS</organization>
+            <roles>
+                <role>Developer</role>
+            </roles>
+        </developer>
     </developers>
 
     <properties>

--- a/repository-companion/pom.xml
+++ b/repository-companion/pom.xml
@@ -308,6 +308,18 @@
                             <exclude>**/integration/*.java</exclude>
                             <exclude>**/integration/**/*.java</exclude>
                         </excludes>
+                        <!-- Note: IGNITE_SKIP_CONFIGURATION_CONSISTENCY_CHECK is hopefully temporary until https://github.com/aldica/aldica/issues/39 is fixed upstream -->
+                        <argLine><![CDATA[
+                            -Xmx512M
+                            -Dfile.encoding=UTF-8
+                            -Djava.net.preferIPv4Stack=true
+                            -DIGNITE_PERFORMANCE_SUGGESTIONS_DISABLED=true
+                            -DIGNITE_QUIET=true
+                            -DIGNITE_NO_ASCII=true
+                            -DIGNITE_UPDATE_NOTIFIER=false
+                            -DIGNITE_JVM_PAUSE_DETECTOR_DISABLED=true
+                            -DIGNITE_SKIP_CONFIGURATION_CONSISTENCY_CHECK=true
+                        ]]></argLine>
                     </configuration>
                 </plugin>
 
@@ -398,24 +410,6 @@
                                 </run>
                             </image>
                         </images>
-                    </configuration>
-                </plugin>
-
-                <plugin>
-                    <artifactId>maven-surefire-plugin</artifactId>
-                    <configuration>
-                        <!-- Note: IGNITE_SKIP_CONFIGURATION_CONSISTENCY_CHECK is hopefully temporary until https://github.com/aldica/aldica/issues/39 is fixed upstream -->
-                        <argLine><![CDATA[
-                            -Xmx512M
-                            -Dfile.encoding=UTF-8
-                            -Djava.net.preferIPv4Stack=true
-                            -DIGNITE_PERFORMANCE_SUGGESTIONS_DISABLED=true
-                            -DIGNITE_QUIET=true
-                            -DIGNITE_NO_ASCII=true
-                            -DIGNITE_UPDATE_NOTIFIER=false
-                            -DIGNITE_JVM_PAUSE_DETECTOR_DISABLED=true
-                            -DIGNITE_SKIP_CONFIGURATION_CONSISTENCY_CHECK=true
-                        ]]></argLine>
                     </configuration>
                 </plugin>
             </plugins>

--- a/repository-companion/pom.xml
+++ b/repository-companion/pom.xml
@@ -9,7 +9,7 @@
     <parent>
         <groupId>org.aldica</groupId>
         <artifactId>aldica-parent</artifactId>
-        <version>1.0.0-SNAPSHOT</version>
+        <version>1.0.0</version>
     </parent>
 
     <artifactId>aldica-repo-ignite-companion</artifactId>

--- a/repository-companion/src/main/resources/3RD-PARTY
+++ b/repository-companion/src/main/resources/3RD-PARTY
@@ -2,7 +2,7 @@ TODO Include notices for Spring, SLF4J, Logback, Alfresco Core
 -----------------------------------------------------------------------------
                         Apache License, Version 2.0
         applies to: 
-        - Apache Ignite, Copyright 2019 The Apache Software Foundation
+        - Apache Ignite, Copyright 2020 The Apache Software Foundation
         - IntelliJ IDEA Annotations, Copyright (C) JetBrains s.r.o.
 -----------------------------------------------------------------------------
 

--- a/repository/module.properties
+++ b/repository/module.properties
@@ -3,8 +3,6 @@
 # file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
 module.id=${moduleId}
-# previously commercially available as an Acosix module
-module.aliases=de.acosix.alfresco.ignite.repo
 module.title=${project.name}
 module.description=${project.description}
 module.version=${noSnapshotVersion}

--- a/repository/pom.xml
+++ b/repository/pom.xml
@@ -9,7 +9,7 @@
     <parent>
         <groupId>org.aldica</groupId>
         <artifactId>aldica-parent</artifactId>
-        <version>1.0.0-SNAPSHOT</version>
+        <version>1.0.0</version>
     </parent>
 
     <artifactId>aldica-repo-ignite</artifactId>

--- a/repository/src/main/config/3RD-PARTY
+++ b/repository/src/main/config/3RD-PARTY
@@ -1,7 +1,7 @@
 -----------------------------------------------------------------------------
                         Apache License, Version 2.0
         applies to: 
-        - Apache Ignite, Copyright 2019 The Apache Software Foundation
+        - Apache Ignite, Copyright 2020 The Apache Software Foundation
         - IntelliJ IDEA Annotations, Copyright (C) JetBrains s.r.o.
 -----------------------------------------------------------------------------
 

--- a/share/pom.xml
+++ b/share/pom.xml
@@ -9,7 +9,7 @@
     <parent>
         <groupId>org.aldica</groupId>
         <artifactId>aldica-parent</artifactId>
-        <version>1.0.0-SNAPSHOT</version>
+        <version>1.0.0</version>
     </parent>
 
     <artifactId>aldica-share-ignite</artifactId>

--- a/share/src/main/config/3RD-PARTY
+++ b/share/src/main/config/3RD-PARTY
@@ -1,7 +1,7 @@
 -----------------------------------------------------------------------------
                         Apache License, Version 2.0
         applies to: 
-        - Apache Ignite, Copyright 2019 The Apache Software Foundation
+        - Apache Ignite, Copyright 2020 The Apache Software Foundation
         - IntelliJ IDEA Annotations, Copyright (C) JetBrains s.r.o.
 -----------------------------------------------------------------------------
 


### PR DESCRIPTION
This PR includes various changes relevant for the finalisation and deployment of the initial aldica release to Maven Central.

This includes:
- copyright adjustments to reflect the current year
- removal of SNAPSHOT dependencies
- Dockerfile sample updates to reflect updated versions and/or reduce hard-coded version references
- alternative Dockerfile samples for simply downloading the pre-built AMPs (once released)
- last minor documentation touch ups
- (as best as possible with minor changes) cleanup of POMs to reduce / eliminate any Maven build warnings
- (eventually) removal of SNAPSHOT suffix from aldica version in parent + sub-module POMs

@andreaskring / @Skeen : Please update parent POM with Magenta contributor details