### PR TITLE
Correct NOTICE file

### DIFF
--- a/NOTICE
+++ b/NOTICE
@@ -1,4 +1,4 @@
-Alfresco Community Open Grid
+Alternative/Alfresco Distributed Cache (aldica)
 Copyright 2020 Acosix GmbH
 Copyright 2020 MAGENTA ApS
 


### PR DESCRIPTION
### CHECKLIST

We will not consider a PR until the following items are checked off--thank you!

- [x] There aren't existing pull requests attempting to address the issue mentioned here
- [x] Submission developed in a feature branch--not master

### CONVINCING DESCRIPTION

This PR corrects the NOTICE file to properly refer to the module as "Alternative/Alfresco Distributed Cache (aldica)" instead of the once working title "Alfresco Community Open Grid".

### RELATED INFORMATION

N/A