### PR TITLE
Collected minor fixes after 1.0.0 release (maintenance)

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -5,9 +5,13 @@ name: Java CI with Maven
 
 on:
   push:
-    branches: [ master ]
+    branches:
+      - master
+      - 'maintenance/**'
   pull_request:
-    branches: [ master ]
+    branches:
+      - master
+      - 'maintenance/**'
 
 jobs:
   build:

--- a/common/pom.xml
+++ b/common/pom.xml
@@ -9,7 +9,7 @@
     <parent>
         <groupId>org.aldica</groupId>
         <artifactId>aldica-parent</artifactId>
-        <version>1.0.0</version>
+        <version>1.0.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>aldica-common-ignite</artifactId>

--- a/common/pom.xml
+++ b/common/pom.xml
@@ -9,7 +9,7 @@
     <parent>
         <groupId>org.aldica</groupId>
         <artifactId>aldica-parent</artifactId>
-        <version>1.0.1-SNAPSHOT</version>
+        <version>1.0.1</version>
     </parent>
 
     <artifactId>aldica-common-ignite</artifactId>

--- a/memory-bm/pom.xml
+++ b/memory-bm/pom.xml
@@ -9,7 +9,7 @@
     <parent>
         <groupId>org.aldica</groupId>
         <artifactId>aldica-parent</artifactId>
-        <version>1.0.1-SNAPSHOT</version>
+        <version>1.0.1</version>
     </parent>
 
     <artifactId>aldica-repo-ignite-mem-bm</artifactId>

--- a/memory-bm/pom.xml
+++ b/memory-bm/pom.xml
@@ -9,7 +9,7 @@
     <parent>
         <groupId>org.aldica</groupId>
         <artifactId>aldica-parent</artifactId>
-        <version>1.0.0</version>
+        <version>1.0.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>aldica-repo-ignite-mem-bm</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -14,7 +14,7 @@
 
     <groupId>org.aldica</groupId>
     <artifactId>aldica-parent</artifactId>
-    <version>1.0.0</version>
+    <version>1.0.1-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <name>Alternative/Alfresco Distributed Cache - Parent</name>

--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
     <parent>
         <groupId>de.acosix.alfresco.maven</groupId>
         <artifactId>de.acosix.alfresco.maven.project.parent-6.1.2</artifactId>
-        <version>1.3.2</version>
+        <version>1.3.3</version>
     </parent>
 
     <groupId>org.aldica</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -14,7 +14,7 @@
 
     <groupId>org.aldica</groupId>
     <artifactId>aldica-parent</artifactId>
-    <version>1.0.1-SNAPSHOT</version>
+    <version>1.0.1</version>
     <packaging>pom</packaging>
 
     <name>Alternative/Alfresco Distributed Cache - Parent</name>

--- a/repository-companion/pom.xml
+++ b/repository-companion/pom.xml
@@ -9,7 +9,7 @@
     <parent>
         <groupId>org.aldica</groupId>
         <artifactId>aldica-parent</artifactId>
-        <version>1.0.1-SNAPSHOT</version>
+        <version>1.0.1</version>
     </parent>
 
     <artifactId>aldica-repo-ignite-companion</artifactId>

--- a/repository-companion/pom.xml
+++ b/repository-companion/pom.xml
@@ -9,7 +9,7 @@
     <parent>
         <groupId>org.aldica</groupId>
         <artifactId>aldica-parent</artifactId>
-        <version>1.0.0</version>
+        <version>1.0.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>aldica-repo-ignite-companion</artifactId>

--- a/repository/pom.xml
+++ b/repository/pom.xml
@@ -9,7 +9,7 @@
     <parent>
         <groupId>org.aldica</groupId>
         <artifactId>aldica-parent</artifactId>
-        <version>1.0.0</version>
+        <version>1.0.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>aldica-repo-ignite</artifactId>

--- a/repository/pom.xml
+++ b/repository/pom.xml
@@ -9,7 +9,7 @@
     <parent>
         <groupId>org.aldica</groupId>
         <artifactId>aldica-parent</artifactId>
-        <version>1.0.1-SNAPSHOT</version>
+        <version>1.0.1</version>
     </parent>
 
     <artifactId>aldica-repo-ignite</artifactId>

--- a/repository/src/main/java/org/aldica/repo/ignite/cache/CacheFactoryImpl.java
+++ b/repository/src/main/java/org/aldica/repo/ignite/cache/CacheFactoryImpl.java
@@ -698,6 +698,12 @@ public class CacheFactoryImpl<K extends Serializable, V extends Serializable> ex
                 if ("afterInstanceStartup".equals(methodName) && args.length == 1
                         && EqualsHelper.nullSafeEquals(CacheFactoryImpl.this.instanceName, args[0]))
                 {
+                    // cannot rely on lifecycle call ordering based on some inherent Spring order, so forward to factory itself
+                    if (!CacheFactoryImpl.this.instanceStarted)
+                    {
+                        CacheFactoryImpl.this.afterInstanceStartup(CacheFactoryImpl.this.instanceName);
+                    }
+
                     if (!this.swapped)
                     {
                         final SimpleCache newCache = CacheFactoryImpl.this.createCache(this.cacheName, false);

--- a/repository/src/main/java/org/aldica/repo/ignite/policy/DictionaryModelActivationChange.java
+++ b/repository/src/main/java/org/aldica/repo/ignite/policy/DictionaryModelActivationChange.java
@@ -244,7 +244,7 @@ public class DictionaryModelActivationChange extends TransactionListenerAdapter
                 affectedTenants.addAll(pendingDeactivation.stream().map(nodeTenantMapper).collect(Collectors.toSet()));
 
                 LOGGER.debug("Sending message about dictionary model (de)activations in tenants {} to grid servers {}", affectedTenants,
-                        remotes.node());
+                        remotes.nodes());
 
                 affectedTenants.forEach(tenant -> ignite.message(remotes).send(DictionaryModelActivationChange.class.getName(), tenant));
             }

--- a/repository/src/main/webscripts/org/aldica/aldica-repo-ignite/admin/ignite/ignite-data-regions.get.html.ftl
+++ b/repository/src/main/webscripts/org/aldica/aldica-repo-ignite/admin/ignite/ignite-data-regions.get.html.ftl
@@ -50,8 +50,10 @@
                                     <td>${regionMetrics.name?html}</td>
                                     <#if regionMetrics.pageSize != 0>
                                         <td title="${regionMetrics.pageSize?c}">${formatSize(regionMetrics.pageSize)?html}</td>
+                                    <#elseif regionMetrics.totalAllocatedPages != 0>
+                                        <td title="${((regionMetrics.totalAllocatedSize / regionMetrics.totalAllocatedPages / 1024)?floor * 1024)?c}">${formatSize((regionMetrics.totalAllocatedSize / regionMetrics.totalAllocatedPages / 1024)?floor * 1024)?html}</td>
                                     <#else>
-                                        <td title="${(regionMetrics.totalAllocatedSize / regionMetrics.totalAllocatedPages)?c}">${formatSize(regionMetrics.totalAllocatedSize / regionMetrics.totalAllocatedPages)?html}</td>
+                                        <td></td>
                                     </#if>
                                     <td>${regionMetrics.totalAllocatedPages?c}</td>
                                     <td title="${regionMetrics.totalAllocatedSize?c}">${formatSize(regionMetrics.totalAllocatedSize)?html}</td>
@@ -61,8 +63,10 @@
                                     <td>${regionMetrics.totalUsedPages?c}</td>
                                     <#if regionMetrics.pageSize != 0>
                                         <td title="${(regionMetrics.totalUsedPages * regionMetrics.pageSize)?c}">${formatSize(regionMetrics.totalUsedPages * regionMetrics.pageSize)?html}</td>
-                                    <#else>
+                                    <#elseif regionMetrics.totalAllocatedPages != 0>
                                         <td title="${(regionMetrics.totalUsedPages / regionMetrics.totalAllocatedPages * regionMetrics.totalAllocatedSize)?c}">${formatSize(regionMetrics.totalUsedPages / regionMetrics.totalAllocatedPages * regionMetrics.totalAllocatedSize)?html}</td>
+                                    <#else>
+                                        <td></td>
                                     </#if>
                                 </tr>
                             </#list>

--- a/repository/src/main/webscripts/org/aldica/aldica-repo-ignite/admin/ignite/ignite-data-regions.get.properties
+++ b/repository/src/main/webscripts/org/aldica/aldica-repo-ignite/admin/ignite/ignite-data-regions.get.properties
@@ -3,7 +3,7 @@
 # file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
 ignite.regions.title=Ignite Data Regions
-ignite.regions.intro=This view shows metrics about all data regions from Ignite grid(s) used on this Repository instance.
+ignite.regions.intro=This view shows metrics about all data regions from all nodes of Ignite grid(s) to which this Repository instance is connected.
 
 ignite.regions.attr.grid.label=Grid
 ignite.regions.attr.grid.title=Name of grid

--- a/repository/src/main/webscripts/org/aldica/aldica-repo-ignite/admin/ignite/ignite-data-regions.get_de.properties
+++ b/repository/src/main/webscripts/org/aldica/aldica-repo-ignite/admin/ignite/ignite-data-regions.get_de.properties
@@ -3,7 +3,7 @@
 # file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
 ignite.regions.title=Ignite Speicherbereiche
-ignite.regions.intro=Diese Ansicht stellt ein Abbild von Speicherbereichen aller Ignite Grids dar, die auf dieser Repository Instanz genutzt werden.
+ignite.regions.intro=Diese Ansicht stellt ein Abbild von Speicherbereichen der verbundenden Knoten aller Ignite Grids dar, mit denen diese Repository Instanz verbunden ist.
 
 ignite.regions.attr.grid.label=Grid
 ignite.regions.attr.grid.title=Grid-Name

--- a/share/pom.xml
+++ b/share/pom.xml
@@ -9,7 +9,7 @@
     <parent>
         <groupId>org.aldica</groupId>
         <artifactId>aldica-parent</artifactId>
-        <version>1.0.0</version>
+        <version>1.0.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>aldica-share-ignite</artifactId>

--- a/share/pom.xml
+++ b/share/pom.xml
@@ -9,7 +9,7 @@
     <parent>
         <groupId>org.aldica</groupId>
         <artifactId>aldica-parent</artifactId>
-        <version>1.0.1-SNAPSHOT</version>
+        <version>1.0.1</version>
     </parent>
 
     <artifactId>aldica-share-ignite</artifactId>


### PR DESCRIPTION
### CHECKLIST

We will not consider a PR until the following items are checked off--thank you!

- [x] There aren't existing pull requests attempting to address the issue mentioned here
- [x] Submission developed in a feature branch--not master

### CONVINCING DESCRIPTION

This PR addresses various minor issues found after the release of 1.0.0.

- In single server installations, the last change to the data regions web script would fail and prevent inspection of the data region sizes (relevant for running memory benchmark), because Ignite fails on attempts to broadcast to an empty list of remote servers.
- While looking through log output of integration tests, I also noticed that the logging in the handling of dictionary model activations would only list one remote server even when the grid consisted of 3 or more servers.
- In one constellation when testing a commercialised variant of this addon, the grid startup lifecycle ended up swapping caches before the factory was informed about the startup, so a guard needed to be added.
- The parent POM had an issue with a SNAPSHOT dependency left in by accident - the updated parent POM fixes this.
- The fallback math in the admin console tool for data regions if a data region does not provide a page size / detailed metrics allowed for a division by zero case. This has been addressed.
- Clarification in data regions that it shows region details of all nodes in the grids to which the Repository instance is connected (otherwise we would not be able to show details about companion apps)

Note: In order to cleanly separate such small fixes that may lead to a 1.0.x update release in a short time from next release kind of work, I have created a maintenance/1.0.x branch and applied to it the same branch rules as for master. This means there will be a second PR like this aimed at master.

### RELATED INFORMATION

N/A

# BE WARNED

- If any of the checklist items are missed, incomplete or invalid we will not accept the PR
- If you are not responsive to feedback on your PR we will not accept the PR
- If we do not accept your PR we will provide feedback on the PR indicating why
- After some time, we will close PRs that have not been accepted

When we decline or close your PR. You are encouraged to address the concerns outlined in the
PR and then re-submit it. We want contributions. We also need for them to be of high quality
and high value and to not take undue resources away from the features and enhancements the
core team is working on. Thanks for understanding!
