### PR TITLE
Multiple repo and Share nodes in Docker-compose

### DIFF
--- a/docker/Dockerfile.nginx.lb
+++ b/docker/Dockerfile.nginx.lb
@@ -1,0 +1,5 @@
+FROM nginx:alpine
+
+WORKDIR /usr/share/nginx/html
+
+COPY docker/nginx.conf /etc/nginx/nginx.conf

--- a/docker/Dockerfile.repo.build
+++ b/docker/Dockerfile.repo.build
@@ -1,8 +1,19 @@
 # Build aldica-ignite AMPs
-FROM maven:3-jdk-11
-ADD docker/toolchains.xml /root/.m2/
+
+# Global ARG for all build stages
+ARG ACOSIX_UTILS_VERSION=1.2.2
+
+FROM maven:3-jdk-11 as builder
+
+ARG ACOSIX_UTILS_VERSION
 
 WORKDIR /aldica
+
+# Copy Acosix dependency to image
+RUN mvn dependency:copy -Dartifact=de.acosix.alfresco.utility:de.acosix.alfresco.utility.core.repo:${ACOSIX_UTILS_VERSION}:amp -DoutputDirectory=deps -B
+
+ADD docker/toolchains.xml /root/.m2/
+
 ADD LICENSE .
 ADD NOTICE .
 ADD pom.xml .
@@ -16,17 +27,21 @@ ADD share share
 RUN sed -i 's/de.acosix.alfresco.maven.project.parent-6.1.2/de.acosix.alfresco.maven.project.parent-6.2.0/g' pom.xml
 # The above cannot be handled by templating in the POM since Maven does not allow this in the <parent> section
 
+# Download ALL Maven dependencies as a separate Docker layer (Docker cache optimisation)
+RUN mvn package -B -DskipTests -DskipMain -pl common,repository
+
 # Build aldica and copy dependencies
-RUN mvn install -B -T2C -DskipTests -Dquality.findBugs.skip -pl common,repository
-RUN mvn dependency:copy -Dartifact=de.acosix.alfresco.utility:de.acosix.alfresco.utility.core.repo:1.2.2:amp -DoutputDirectory=target -B
+RUN mvn install -B -DskipTests -Dquality.findBugs.skip -pl common,repository
 
 # Build aldica-enabled Alfresco Repository
 FROM alfresco/alfresco-content-repository-community:6.2.0-ga
 
-COPY --from=0 --chown=root:Alfresco /aldica/repository/target/aldica-repo-ignite-*.amp .
-COPY --from=0 --chown=root:Alfresco /aldica/target/de.acosix.alfresco.utility.core.repo-*.amp .
+ARG ACOSIX_UTILS_VERSION
+
+COPY --from=0 --chown=root:Alfresco /aldica/repository/target/aldica-repo-ignite-*.amp ./amps/
+COPY --from=0 --chown=root:Alfresco /aldica/deps/de.acosix.alfresco.utility.core.repo-${ACOSIX_UTILS_VERSION}.amp ./amps/
 
 USER root
-RUN java -jar alfresco-mmt/alfresco-mmt-6.0.jar install de.acosix.alfresco.utility.core.repo-*.amp webapps/alfresco -nobackup
-RUN java -jar alfresco-mmt/alfresco-mmt-6.0.jar install aldica-repo-ignite-*.amp webapps/alfresco -nobackup
+RUN java -jar alfresco-mmt/alfresco-mmt-6.0.jar install ./amps/de.acosix.alfresco.utility.core.repo-${ACOSIX_UTILS_VERSION}.amp webapps/alfresco -nobackup
+RUN java -jar alfresco-mmt/alfresco-mmt-6.0.jar install ./amps/aldica-repo-ignite-*.amp webapps/alfresco -nobackup
 USER alfresco

--- a/docker/Dockerfile.repo.download
+++ b/docker/Dockerfile.repo.download
@@ -1,18 +1,25 @@
+# Global ARG for all build stages
+ARG ACOSIX_UTILS_VERSION=1.2.2
+
 # Download AMPs
 FROM maven:3-jdk-11
 
-RUN mvn dependency:copy -Dartifact=de.acosix.alfresco.utility:de.acosix.alfresco.utility.core.repo:1.2.2:amp -DoutputDirectory=/tmp -B
-RUN mvn dependency:copy -Dartifact=org.aldica:aldica-repo-ignite:1.0.0:amp -DoutputDirectory=/tmp -B
+ARG ACOSIX_UTILS_VERSION
+
+RUN mvn dependency:copy -Dartifact=de.acosix.alfresco.utility:de.acosix.alfresco.utility.core.repo:${ACOSIX_UTILS_VERSION}:amp -DoutputDirectory=/tmp -B
+RUN mvn dependency:copy -Dartifact=org.aldica:aldica-repo-ignite:1.0.1:amp -DoutputDirectory=/tmp -B
 
 # Build aldica-enabled Alfresco Repository
 FROM alfresco/alfresco-content-repository-community:6.2.0-ga
 
-COPY --from=0 --chown=root:Alfresco /tmp/aldica-repo-ignite-1.0.0.amp .
-COPY --from=0 --chown=root:Alfresco /tmp/de.acosix.alfresco.utility.core.repo-1.2.2.amp .
+ARG ACOSIX_UTILS_VERSION
+
+COPY --from=0 --chown=root:Alfresco /tmp/aldica-repo-ignite-1.0.1.amp .
+COPY --from=0 --chown=root:Alfresco /tmp/de.acosix.alfresco.utility.core.repo-${ACOSIX_UTILS_VERSION}.amp .
 
 USER root
 
-RUN java -jar alfresco-mmt/alfresco-mmt-6.0.jar install de.acosix.alfresco.utility.core.repo-1.2.2.amp webapps/alfresco -nobackup
-RUN java -jar alfresco-mmt/alfresco-mmt-6.0.jar install aldica-repo-ignite-1.0.0.amp webapps/alfresco -nobackup
+RUN java -jar alfresco-mmt/alfresco-mmt-6.0.jar install de.acosix.alfresco.utility.core.repo-${ACOSIX_UTILS_VERSION}.amp webapps/alfresco -nobackup
+RUN java -jar alfresco-mmt/alfresco-mmt-6.0.jar install aldica-repo-ignite-1.0.1.amp webapps/alfresco -nobackup
 
 USER alfresco

--- a/docker/Dockerfile.share.build
+++ b/docker/Dockerfile.share.build
@@ -1,8 +1,19 @@
 # Build aldica-ignite AMPs
+
+# Global ARG for all build stages
+ARG ACOSIX_UTILS_VERSION=1.2.2
+
 FROM maven:3-jdk-11
-ADD docker/toolchains.xml /root/.m2/
+
+ARG ACOSIX_UTILS_VERSION
 
 WORKDIR /aldica
+
+# Copy Acosix dependency to image
+RUN mvn dependency:copy -Dartifact=de.acosix.alfresco.utility:de.acosix.alfresco.utility.core.share:${ACOSIX_UTILS_VERSION}:amp -DoutputDirectory=deps -B
+
+ADD docker/toolchains.xml /root/.m2/
+
 ADD LICENSE .
 ADD NOTICE .
 ADD pom.xml .
@@ -15,15 +26,19 @@ ADD share share
 RUN sed -i 's/de.acosix.alfresco.maven.project.parent-6.1.2/de.acosix.alfresco.maven.project.parent-6.2.0/g' pom.xml
 # The above cannot be handled by templating in the POM since Maven does not allow this in the <parent> section
 
+# Download ALL Maven dependencies as a separate Docker layer (Docker cache optimisation)
+RUN mvn package -B -DskipTests -DskipMain
+
 # Build aldica and copy dependencies (we need to build both repo and share due to dependency issues)
-RUN mvn install -B -T2C -DskipTests -Dquality.findBugs.skip
-RUN mvn dependency:copy -Dartifact=de.acosix.alfresco.utility:de.acosix.alfresco.utility.core.share:1.2.2:amp -DoutputDirectory=target -B
+RUN mvn install -B -DskipTests -Dquality.findBugs.skip
 
 # Build aldica-enabled Alfresco Share
 FROM alfresco/alfresco-share:6.2.0
 
-COPY --from=0 /aldica/share/target/aldica-share-ignite-*.amp .
-COPY --from=0 /aldica/target/de.acosix.alfresco.utility.core.share-*.amp .
+ARG ACOSIX_UTILS_VERSION
 
-RUN java -jar alfresco-mmt/alfresco-mmt-6.0.jar install de.acosix.alfresco.utility.core.share-*.amp webapps/share -force -nobackup
-RUN java -jar alfresco-mmt/alfresco-mmt-6.0.jar install aldica-share-ignite-*.amp webapps/share -nobackup
+COPY --from=0 /aldica/share/target/aldica-share-ignite-*.amp ./amps_share/
+COPY --from=0 /aldica/deps/de.acosix.alfresco.utility.core.share-${ACOSIX_UTILS_VERSION}.amp ./amps_share/
+
+RUN java -jar alfresco-mmt/alfresco-mmt-6.0.jar install ./amps_share/de.acosix.alfresco.utility.core.share-${ACOSIX_UTILS_VERSION}.amp webapps/share -force -nobackup
+RUN java -jar alfresco-mmt/alfresco-mmt-6.0.jar install ./amps_share/aldica-share-ignite-*.amp webapps/share -nobackup

--- a/docker/Dockerfile.share.download
+++ b/docker/Dockerfile.share.download
@@ -1,14 +1,24 @@
+# Global ARG for all build stages
+ARG ACOSIX_UTILS_VERSION=1.2.2
+
 # Download AMPs
 FROM maven:3-jdk-11
 
-RUN mvn dependency:copy -Dartifact=de.acosix.alfresco.utility:de.acosix.alfresco.utility.core.share:1.2.2:amp -DoutputDirectory=/tmp -B
-RUN mvn dependency:copy -Dartifact=org.aldica:aldica-share-ignite:1.0.0:amp -DoutputDirectory=/tmp -B
+ARG ACOSIX_UTILS_VERSION
+
+RUN mvn dependency:copy -Dartifact=de.acosix.alfresco.utility:de.acosix.alfresco.utility.core.share:${ACOSIX_UTILS_VERSION}:amp -DoutputDirectory=/tmp -B
+RUN mvn dependency:copy -Dartifact=org.aldica:aldica-share-ignite:1.0.1:amp -DoutputDirectory=/tmp -B
 
 # Build aldica-enabled Alfresco Share
 FROM alfresco/alfresco-share:6.2.0
 
-COPY --from=0 /tmp/aldica-share-ignite-1.0.0-SNAPSHOT.amp .
-COPY --from=0 /tmp/de.acosix.alfresco.utility.core.share-1.2.2.amp .
+ARG ACOSIX_UTILS_VERSION
 
-RUN java -jar alfresco-mmt/alfresco-mmt-6.0.jar install de.acosix.alfresco.utility.core.share-1.2.2.amp webapps/share -force -nobackup
-RUN java -jar alfresco-mmt/alfresco-mmt-6.0.jar install aldica-share-ignite-1.0.0.amp webapps/share -nobackup
+# Disable CSRF filter (do not use this in production)
+COPY docker/share-config-custom-dev.xml /usr/local/tomcat/shared/classes/alfresco/web-extension/share-config-custom-dev.xml
+
+COPY --from=0 /tmp/aldica-share-ignite-1.0.1.amp .
+COPY --from=0 /tmp/de.acosix.alfresco.utility.core.share-${ACOSIX_UTILS_VERSION}.amp .
+
+RUN java -jar alfresco-mmt/alfresco-mmt-6.0.jar install de.acosix.alfresco.utility.core.share-${ACOSIX_UTILS_VERSION}.amp webapps/share -force -nobackup
+RUN java -jar alfresco-mmt/alfresco-mmt-6.0.jar install aldica-share-ignite-1.0.1.amp webapps/share -nobackup

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -5,15 +5,16 @@
 # If the container memory is not explicitly set then the flags above will set the max heap default to 1/4 of the container's memory, which may not be ideal.
 # For performance tuning, assign the container memory and give a percentage of it to the JVM.
 
-# Using version 2 as 3 does not support resource constraint options (cpu_*, mem_* limits) for non swarm mode in Compose
-version: "2"
+version: "3.5"
 
 services:
-    alfresco:
+    alfresco1:
+        depends_on:
+            - postgres
+        image: aldica/repo:1.0.1
         build:
-          context: ..
-          dockerfile: docker/Dockerfile.repo.build
-        mem_limit: 1500m
+            context: ..
+            dockerfile: docker/Dockerfile.repo.download
         environment:
             JAVA_OPTS: "
                 -Ddb.driver=org.postgresql.Driver
@@ -25,7 +26,7 @@ services:
                 -Dsolr.secureComms=none
                 -Dsolr.base.url=/solr
                 -Dindex.subsystem.name=solr6
-                -Dshare.host=127.0.0.1
+                -Dshare.host=loadbalancer
                 -Dshare.port=8080
                 -Dalfresco.host=localhost
                 -Dalfresco.port=8080
@@ -48,12 +49,131 @@ services:
                 -Dtransform.misc.url=http://transform-misc:8090/
 
                 -Dcsrf.filter.enabled=false
-                -Xms1500m -Xmx1500m
-                "
+
+                --add-exports=java.base/jdk.internal.misc=ALL-UNNAMED
+                --add-exports=java.base/sun.nio.ch=ALL-UNNAMED
+                --add-exports=java.management/com.sun.jmx.mbeanserver=ALL-UNNAMED
+                --add-exports=jdk.internal.jvmstat/sun.jvmstat.monitor=ALL-UNNAMED
+                --add-exports=java.base/sun.reflect.generics.reflectiveObjects=ALL-UNNAMED
+                --illegal-access=permit
+
+                -Xms1500m
+                -Xmx2000m
+
+                -XX:+UseG1GC
+                -XX:+ParallelRefProcEnabled
+                -XX:+UseStringDeduplication
+                -XX:+ScavengeBeforeFullGC
+                -XX:+DisableExplicitGC
+                -XX:+AlwaysPreTouch
+
+                -Dfile.encoding=UTF-8
+                -Djava.net.preferIPv4Stack=true
+
+                -DIGNITE_PERFORMANCE_SUGGESTIONS_DISABLED=true
+                -DIGNITE_QUIET=true
+                -DIGNITE_NO_ASCII=true
+                -DIGNITE_UPDATE_NOTIFIER=false
+                -DIGNITE_JVM_PAUSE_DETECTOR_DISABLED=true
+                -DIGNITE_SKIP_CONFIGURATION_CONSISTENCY_CHECK=true
+
+                -Daldica.caches.remoteSupport.enabled=true
+                -Daldica.core.local.id=alfresco1
+                -Daldica.core.public.host=alfresco1
+            "
+        # Expose Tomcat port for convenience
+        ports:
+            - 8081:8080
+        # The two Alfresco repositories need to share files
+        volumes:
+            - type: volume
+              source: alfresco-data-volume
+              target: /usr/local/tomcat/alf_data
+
+    alfresco2:
+        depends_on:
+            - postgres
+        image: aldica/repo:1.0.1
+        build:
+            context: ..
+            dockerfile: docker/Dockerfile.repo.download
+        environment:
+            JAVA_OPTS: "
+                -Ddb.driver=org.postgresql.Driver
+                -Ddb.username=alfresco
+                -Ddb.password=alfresco
+                -Ddb.url=jdbc:postgresql://postgres:5432/alfresco
+                -Dsolr.host=solr6
+                -Dsolr.port=8983
+                -Dsolr.secureComms=none
+                -Dsolr.base.url=/solr
+                -Dindex.subsystem.name=solr6
+                -Dshare.host=loadbalancer
+                -Dshare.port=8080
+                -Dalfresco.host=localhost
+                -Dalfresco.port=8080
+                -Daos.baseUrlOverwrite=http://localhost:8080/alfresco/aos
+                -Dmessaging.broker.url=\"failover:(nio://activemq:61616)?timeout=3000&jms.useCompression=true\"
+                -Ddeployment.method=DOCKER_COMPOSE
+
+                -Dlocal.transform.service.enabled=true
+                -DlocalTransform.pdfrenderer.url=http://alfresco-pdf-renderer:8090/
+                -DlocalTransform.imagemagick.url=http://imagemagick:8090/
+                -DlocalTransform.libreoffice.url=http://libreoffice:8090/
+                -DlocalTransform.tika.url=http://tika:8090/
+                -DlocalTransform.misc.url=http://transform-misc:8090/
+
+                -Dlegacy.transform.service.enabled=true
+                -Dalfresco-pdf-renderer.url=http://alfresco-pdf-renderer:8090/
+                -Djodconverter.url=http://libreoffice:8090/
+                -Dimg.url=http://imagemagick:8090/
+                -Dtika.url=http://tika:8090/
+                -Dtransform.misc.url=http://transform-misc:8090/
+
+                -Dcsrf.filter.enabled=false
+
+                --add-exports=java.base/jdk.internal.misc=ALL-UNNAMED
+                --add-exports=java.base/sun.nio.ch=ALL-UNNAMED
+                --add-exports=java.management/com.sun.jmx.mbeanserver=ALL-UNNAMED
+                --add-exports=jdk.internal.jvmstat/sun.jvmstat.monitor=ALL-UNNAMED
+                --add-exports=java.base/sun.reflect.generics.reflectiveObjects=ALL-UNNAMED
+                --illegal-access=permit
+
+                -Xms1500m
+                -Xmx2000m
+
+                -XX:+UseG1GC
+                -XX:+ParallelRefProcEnabled
+                -XX:+UseStringDeduplication
+                -XX:+ScavengeBeforeFullGC
+                -XX:+DisableExplicitGC
+                -XX:+AlwaysPreTouch
+
+                -Dfile.encoding=UTF-8
+                -Djava.net.preferIPv4Stack=true
+
+                -DIGNITE_PERFORMANCE_SUGGESTIONS_DISABLED=true
+                -DIGNITE_QUIET=true
+                -DIGNITE_NO_ASCII=true
+                -DIGNITE_UPDATE_NOTIFIER=false
+                -DIGNITE_JVM_PAUSE_DETECTOR_DISABLED=true
+                -DIGNITE_SKIP_CONFIGURATION_CONSISTENCY_CHECK=true
+
+                -Daldica.caches.remoteSupport.enabled=true
+                -Daldica.core.local.id=alfresco2
+                -Daldica.core.public.host=alfresco2
+            "
+        # Expose Tomcat port for convenience
+        ports:
+            - 8082:8080
+        # The two Alfresco repositories need to share files
+        volumes:
+            - type: volume
+              source: alfresco-data-volume
+              target: /usr/local/tomcat/alf_data
 
     alfresco-pdf-renderer:
         image: alfresco/alfresco-pdf-renderer:2.1.0
-        mem_limit: 1g
         environment:
             JAVA_OPTS: " -Xms256m -Xmx512m"
         ports:
@@ -61,7 +181,6 @@ services:
 
     imagemagick:
         image: alfresco/alfresco-imagemagick:2.1.0
-        mem_limit: 1g
         environment:
             JAVA_OPTS: " -Xms256m -Xmx512m"
         ports:
@@ -69,7 +188,6 @@ services:
 
     libreoffice:
         image: alfresco/alfresco-libreoffice:2.1.0
-        mem_limit: 1g
         environment:
             JAVA_OPTS: " -Xms256m -Xmx512m"
         ports:
@@ -77,7 +195,6 @@ services:
 
     tika:
         image: alfresco/alfresco-tika:2.1.0
-        mem_limit: 1g
         environment:
             JAVA_OPTS: " -Xms256m -Xmx512m"
         ports:
@@ -85,32 +202,63 @@ services:
 
     transform-misc:
         image: alfresco/alfresco-transform-misc:2.1.0
-        mem_limit: 1g
         environment:
             JAVA_OPTS: " -Xms256m -Xmx512m"
         ports:
             - 8094:8090
 
-    share:
+    share1:
+        image: aldica/share:1.0.1
         build:
           context: ..
-          dockerfile: docker/Dockerfile.share.build
-        mem_limit: 1g
+          dockerfile: docker/Dockerfile.share.download
         environment:
-            REPO_HOST: "alfresco"
+            REPO_HOST: "loadbalancer"
             REPO_PORT: "8080"
             JAVA_OPTS: "
                 -Xms500m
                 -Xmx500m
-                -Dalfresco.host=localhost
+                -Dalfresco.host=loadbalancer
                 -Dalfresco.port=8080
                 -Dalfresco.context=alfresco
                 -Dalfresco.protocol=http
+
+                -Daldica.core.local.id=share1
+                -Daldica.core.local.host=share1
+                -Daldica.core.public.host=share1
+                -Daldica.core.initialMembers=share1,share2
                 "
+        # Expose Tomcat port for convenience
+        ports:
+            - 8181:8080
+
+    share2:
+        image: aldica/share:1.0.1
+        build:
+            context: ..
+            dockerfile: docker/Dockerfile.share.download
+        environment:
+            REPO_HOST: "loadbalancer"
+            REPO_PORT: "8080"
+            JAVA_OPTS: "
+                -Xms500m
+                -Xmx500m
+                -Dalfresco.host=loadbalancer
+                -Dalfresco.port=8080
+                -Dalfresco.context=alfresco
+                -Dalfresco.protocol=http
+
+                -Daldica.core.local.id=share2
+                -Daldica.core.local.host=share2
+                -Daldica.core.public.host=share2
+                -Daldica.core.initialMembers=share1,share2
+                "
+        # Expose Tomcat port for convenience
+        ports:
+            - 8182:8080
 
     postgres:
         image: postgres:11.4
-        mem_limit: 512m
         environment:
             - POSTGRES_PASSWORD=alfresco
             - POSTGRES_USER=alfresco
@@ -120,11 +268,12 @@ services:
             - 5432:5432
 
     solr6:
+        depends_on:
+            - alfresco1
         image: alfresco/alfresco-search-services:1.4.0
-        mem_limit: 2g
         environment:
             #Solr needs to know how to register itself with Alfresco
-            - SOLR_ALFRESCO_HOST=alfresco
+            - SOLR_ALFRESCO_HOST=loadbalancer
             - SOLR_ALFRESCO_PORT=8080
             #Alfresco needs to know how to call solr
             - SOLR_SOLR_HOST=solr6
@@ -139,20 +288,25 @@ services:
 
     activemq:
         image: alfresco/alfresco-activemq:5.15.8
-        mem_limit: 1g
         ports:
             - 8161:8161 # Web Console
             - 5672:5672 # AMQP
             - 61616:61616 # OpenWire
             - 61613:61613 # STOMP
             
-    proxy:
-        image: alfresco/acs-community-ngnix:1.0.0
-        mem_limit: 128m
+    loadbalancer:
         depends_on:
-            - alfresco
+            - alfresco1
+            - alfresco2
+            - share1
+            - share2
+        image: aldica/lb:1.0.0
+        build:
+            context: ..
+            # dockerfile: docker/Dockerfile.lb
+            dockerfile: docker/Dockerfile.nginx.lb
         ports:
             - 8080:8080
-        links:
-            - alfresco
-            - share     
+
+volumes:
+    alfresco-data-volume:

--- a/docker/nginx.conf
+++ b/docker/nginx.conf
@@ -1,0 +1,29 @@
+worker_processes 1;
+
+events {
+    worker_connections 1024;
+}
+
+http {
+    upstream alfresco {
+        server alfresco1:8080;
+        server alfresco2:8080;
+    }
+
+    upstream share {
+        hash $remote_addr consistent;
+        server share1:8080;
+        server share2:8080;
+    }
+
+    server {
+        listen 8080;
+        location /alfresco {
+            proxy_pass http://alfresco/alfresco;
+        }
+
+        location /share {
+            proxy_pass http://share/share;
+        }
+    }
+}

--- a/docker/share-config-custom-dev.xml
+++ b/docker/share-config-custom-dev.xml
@@ -1,0 +1,5 @@
+<alfresco-config>
+   <config evaluator="string-compare" condition="CSRFPolicy" replace="true">
+      <filter/>
+   </config>
+</alfresco-config>

--- a/docs/Installation-Docker.md
+++ b/docs/Installation-Docker.md
@@ -1,19 +1,31 @@
 # Introduction
 
 A `docker-compose.yml` file is provided in the `docker` sub-folder of the project root.
-This `docker-compose.yml` file is based upon the upstream [Alfresco Content Services Community Deployment](https://github.com/Alfresco/acs-community-deployment) `docker-compose.yml` file.
+This `docker-compose.yml` file is based upon the upstream 
+[Alfresco Content Services Community Deployment](https://github.com/Alfresco/acs-community-deployment) 
+`docker-compose.yml` file, but with a few additions. In order to see the distributed nature of 
+the caching mechanism in action, a small cluster is started by the `docker-compose.yml`. This means
+that two aldica-enabled Alfresco repositories and two aldica-enabled Alfresco Share containers are fired up 
+along with a simple Nginx load balancer. 
 
 # Prerequisites
 * Docker daemon and client
 
 # Installation
-Running `docker-compose up` within the `docker` sub-folder, will:
+Running `docker-compose up -d --build` within the `docker` sub-folder, will:
 
-1. Download and build the [Acosix Alfresco Utility Core](https://github.com/Acosix/alfresco-utility) AMP.
-2. Build the aldica-ignite AMP, according to the documentation in the [build](./Build.md) section.
-3. Build an aldica-enabled Alfresco Repository and Share docker image.
-4. Start-up a docker-compose based Alfresco installation.
+1. Build and start the two aldica-enabled Alfresco repositories.
+1. Build the aldica-enabled Alfresco Share image and start two Share Docker containers.
+1. Build and start the Nginx load balancer
+1. Start all other Alfresco accessory containers (PostgreSQL, Solr6,...)
 
 Note that this will take quite a while (~1 hour), depending on available CPU and network resources.
 
-At which point an aldica-enabled Alfresco stack should be running, and be available on `http://localhost:8080/`
+For convenience, you could set up DNS entries in the `/etc/hosts` file on your host machine:
+```
+127.0.0.1   localhost alfresco1 alfresco2 share1 share2 loadbalancer
+```
+
+The aldica-enabled Alfresco stack should now be running and available on 
+`http://loadbalancer:8080/`. E.g. so if you want to access Share, go to 
+`http://loadbalancer:8080/share/page`.


### PR DESCRIPTION
### CHECKLIST

We will not consider a PR until the following items are checked off--thank you!

- [ X ] There aren't existing pull requests attempting to address the issue mentioned here
- [ X ] Submission developed in a feature branch--not master

### CONVINCING DESCRIPTION

Improvement of the Docker-compose setup. The following has been done:
* The Dockerfiles for Alfresco and Share have been updated
* Two Alfresco repo containers have been configured in `docker-compose.yml`
* Two Share containers have been configured in `docker-compose.yml`
* A Dockerfile for an Nginx load balancer has been added and the load balancer has also been added to the `docker-compose.yml`

With this setup it is easy to start multiple aldica enabled repository and Share containers in order to test the aldica module.

### RELATED INFORMATION

Fixes #53
