### PR TITLE
Deserialize binary cache keys in getKeys()

### DIFF
--- a/repository/src/main/java/org/aldica/repo/ignite/cache/SimpleIgniteBackedCache.java
+++ b/repository/src/main/java/org/aldica/repo/ignite/cache/SimpleIgniteBackedCache.java
@@ -215,7 +215,11 @@ public class SimpleIgniteBackedCache<K extends Serializable, V> implements Simpl
             // use withKeepBinary to avoid unnecessary deseralisation of values
             final IgniteCache<K, ?> cache = this.backingCache.withKeepBinary();
             cache.localEntries(CachePeekMode.ALL).forEach(entry -> {
-                final K key = entry.getKey();
+                K key = entry.getKey();
+                if (key instanceof BinaryObject)
+                {
+                    key = ((BinaryObject) key).deserialize();
+                }
                 keys.add(key);
             });
         }
@@ -229,7 +233,11 @@ public class SimpleIgniteBackedCache<K extends Serializable, V> implements Simpl
                 // use withKeepBinary to avoid unnecessary deseralisation of values
                 final IgniteCache<K, V> cache = Ignition.localIgnite().<K, V> getOrCreateCache(this.cacheName).withKeepBinary();
                 cache.localEntries(CachePeekMode.ALL).forEach(entry -> {
-                    final K key = entry.getKey();
+                    K key = entry.getKey();
+                    if (key instanceof BinaryObject)
+                    {
+                        key = ((BinaryObject) key).deserialize();
+                    }
                     localKeys.add(key);
                 });
                 return localKeys;


### PR DESCRIPTION
### CHECKLIST

We will not consider a PR until the following items are checked off--thank you!

- [x] There aren't existing pull requests attempting to address the issue mentioned here
- [x] Submission developed in a feature branch--not master

### CONVINCING DESCRIPTION

This PR fixes a bug in the handling of the `getKeys` operation on Ignite-backed caches. In order to avoid pro-actively deserialising all keys / values, the `getKeys` operation uses the `withKeepBinary` cache mode. What it lacks though is the necessary handling to then selectively deserialise the retrieved keys before putting them in the return collection.

This issue was discovered while validating the new, cluster-aware enhancements to the encrypted key store, specifically key validatiion among cluster nodes (e.g. [here](https://github.com/Acosix/alfresco-simple-content-stores/blob/3bd896875a0a430f8eddad0f9df80dfe56678426/src/main/java/de/acosix/alfresco/simplecontentstores/repo/store/encrypted/MasterKeyManagerImpl.java#L360)). The issue manifests itself in `ClassCastException` from `BinaryObjectImpl` to the respective key type, whenever and **only if** an actual cast is triggered for elements of the returned collection, which may not be immediate, depending on how/where the compiler decides the generic type parameter must result in an explicit cast. In Alfresco core, `getKeys` is only used for the `InMemoryTicketComponentImpl` and there the key is only a simple String, so likely that is an optimised case in which `BinaryObjectImpl` is not even used.

### RELATED INFORMATION

